### PR TITLE
Feat/signup#2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.security:spring-security-crypto'
 	compileOnly 'org.projectlombok:lombok'  // Lombok (getter/setter 자동 생성 등 편의 기능)
 	runtimeOnly 'org.postgresql:postgresql'  // PostgreSQL 드라이버 (DB 연결용)

--- a/src/main/java/com/signwave/signwave/config/SecurityConfig.java
+++ b/src/main/java/com/signwave/signwave/config/SecurityConfig.java
@@ -4,8 +4,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 @Configuration
 public class SecurityConfig {
 
@@ -24,5 +25,11 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .httpBasic(Customizer.withDefaults())
                 .build();
+    }
+
+    //비밀번호 암호화용 빈 등록
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/signwave/signwave/controller/MemberController.java
+++ b/src/main/java/com/signwave/signwave/controller/MemberController.java
@@ -1,0 +1,27 @@
+package com.signwave.signwave.controller;
+
+import com.signwave.signwave.dto.SignUpRequest;
+import com.signwave.signwave.dto.SignUpResponse;
+import com.signwave.signwave.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Tag(name = "Auth", description = "회원가입 및 인증 관련 API")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입", description = "이메일, 닉네임, 비밀번호로 새로운 사용자를 등록합니다.")
+    public ResponseEntity<SignUpResponse> signup(@RequestBody SignUpRequest request) {
+        SignUpResponse response = memberService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/signwave/signwave/dto/SignUpRequest.java
+++ b/src/main/java/com/signwave/signwave/dto/SignUpRequest.java
@@ -1,0 +1,10 @@
+package com.signwave.signwave.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SignUpRequest {
+    private String email;
+    private String nickname;
+    private String password;
+}

--- a/src/main/java/com/signwave/signwave/dto/SignUpResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/SignUpResponse.java
@@ -1,10 +1,12 @@
 package com.signwave.signwave.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
-public class SignUpRequest {
+@AllArgsConstructor
+public class SignUpResponse {
+    private Long id;
     private String email;
     private String nickname;
-    private String password;
 }

--- a/src/main/java/com/signwave/signwave/entity/Member.java
+++ b/src/main/java/com/signwave/signwave/entity/Member.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder // 추가
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor // Builder용 생성자
 public class Member extends BaseEntity{

--- a/src/main/java/com/signwave/signwave/repository/MemberRepository.java
+++ b/src/main/java/com/signwave/signwave/repository/MemberRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String mail);
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/signwave/signwave/service/MemberService.java
+++ b/src/main/java/com/signwave/signwave/service/MemberService.java
@@ -1,0 +1,30 @@
+package com.signwave.signwave.service;
+
+import com.signwave.signwave.dto.SignUpRequest;
+import com.signwave.signwave.dto.SignUpResponse;
+import com.signwave.signwave.entity.Member;
+import com.signwave.signwave.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public SignUpResponse register(SignUpRequest request) {
+        String encryptedPassword = passwordEncoder.encode(request.getPassword());
+
+        Member member = Member.builder()
+                .email(request.getEmail())
+                .nickname(request.getNickname())
+                .password(encryptedPassword)
+                .build();
+
+        Member saved = memberRepository.save(member);
+        return new SignUpResponse(saved.getId(), saved.getEmail(), saved.getNickname());
+    }
+}


### PR DESCRIPTION
### 연관된 이슈
- #2 

### 작업 내용
- POST /auth/signup 회원가입 API 구현
- 이메일, 닉네임, 비밀번호를 입력받아 새로운 사용자 등록
- BCryptPasswordEncoder를 이용한 비밀번호 암호화 적용
- SignUpRequest, SignUpResponse DTO 생성
- MemberService에 회원 저장 로직 추가
- MemberController에 회원가입 엔드포인트 추가
- Swagger 연동을 위한 설명 어노테이션(@Operation) 적용