### PR TITLE
Feat/add favorite#9

### DIFF
--- a/src/main/java/com/signwave/signwave/dto/FavoriteRequest.java
+++ b/src/main/java/com/signwave/signwave/dto/FavoriteRequest.java
@@ -1,0 +1,8 @@
+package com.signwave.signwave.dto;
+
+import lombok.Data;
+
+@Data
+public class FavoriteRequest {
+    private Long translationHistoryId;
+}

--- a/src/main/java/com/signwave/signwave/dto/FavoriteResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/FavoriteResponse.java
@@ -1,0 +1,10 @@
+package com.signwave.signwave.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class FavoriteResponse {
+    private Long memberId;
+}

--- a/src/main/java/com/signwave/signwave/entity/TranslationHistory.java
+++ b/src/main/java/com/signwave/signwave/entity/TranslationHistory.java
@@ -24,4 +24,9 @@ public class TranslationHistory extends BaseEntity {
     private Member member;
 
     private boolean isFavorite;
+
+    // 즐겨찾기 여부 설정 메서드 추가
+    public void setFavorite(boolean isFavorite) {
+        this.isFavorite = isFavorite;
+    }
 }

--- a/src/main/java/com/signwave/signwave/service/TranslationHistoryService.java
+++ b/src/main/java/com/signwave/signwave/service/TranslationHistoryService.java
@@ -1,0 +1,25 @@
+package com.signwave.signwave.service;
+
+import com.signwave.signwave.dto.FavoriteRequest;
+import com.signwave.signwave.dto.FavoriteResponse;
+import com.signwave.signwave.entity.TranslationHistory;
+import com.signwave.signwave.repository.TranslationHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TranslationHistoryService {
+
+    private final TranslationHistoryRepository historyRepository;
+
+    public FavoriteResponse markAsFavorite(FavoriteRequest request) {
+        TranslationHistory history = historyRepository.findById(request.getTranslationHistoryId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 번역기록이 존재하지 않습니다."));
+
+        history.setFavorite(true); // true로 설정
+        TranslationHistory updated = historyRepository.save(history);
+
+        return new FavoriteResponse(updated.getMember().getId());
+    }
+}


### PR DESCRIPTION
### 연관된 이슈
- #9 

### 작업 내용
- 특정 번역기록을 즐겨찾기로 등록하는 API 구현 (POST /history/favorite)
- 요청 DTO FavoriteRequest에서 번역기록 ID를 전달받아 해당 기록의 isFavorite 값을 true로 변경
- TranslationHistory 엔티티에 즐겨찾기 설정 메서드 setFavorite() 구현
- 즐겨찾기 처리 후, 해당 기록의 Member ID를 포함한 응답 DTO FavoriteResponse 반환
- 유효하지 않은 ID일 경우 IllegalArgumentException 예외 발생
- Swagger 연동을 통해 즐겨찾기 API 테스트 가능