### PR TITLE
Feat/get translation histories#10

### DIFF
--- a/src/main/java/com/signwave/signwave/config/SecurityConfig.java
+++ b/src/main/java/com/signwave/signwave/config/SecurityConfig.java
@@ -29,9 +29,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/translate",
                                 "/auth/**"
-                        ).permitAll()
+                                ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/com/signwave/signwave/controller/TranslationHistoryController.java
+++ b/src/main/java/com/signwave/signwave/controller/TranslationHistoryController.java
@@ -3,11 +3,17 @@ package com.signwave.signwave.controller;
 
 import com.signwave.signwave.dto.FavoriteRequest;
 import com.signwave.signwave.dto.FavoriteResponse;
+import com.signwave.signwave.dto.TranslationHistoryResponse;
+import com.signwave.signwave.entity.Member;
+import com.signwave.signwave.repository.MemberRepository;
 import com.signwave.signwave.service.TranslationHistoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/history")
@@ -15,11 +21,21 @@ import org.springframework.web.bind.annotation.*;
 public class TranslationHistoryController {
 
     private final TranslationHistoryService historyService;
+    private final MemberRepository memberRepository;
 
     @PostMapping("/favorite")
     @Operation(summary = "즐겨찾기 등록", description = "특정 번역기록을 즐겨찾기로 등록합니다.")
     public ResponseEntity<FavoriteResponse> addFavorite(@RequestBody FavoriteRequest request) {
         FavoriteResponse response = historyService.markAsFavorite(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "번역기록 전체 조회", description = "로그인한 사용자의 전체 번역기록을 조회합니다.")
+    public ResponseEntity<List<TranslationHistoryResponse>> getAllHistories(@AuthenticationPrincipal String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+        List<TranslationHistoryResponse> response = historyService.getAllHistoriesByMember(member);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/signwave/signwave/controller/TranslationHistoryController.java
+++ b/src/main/java/com/signwave/signwave/controller/TranslationHistoryController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.security.core.Authentication;
 
 import java.util.List;
 
@@ -33,11 +34,12 @@ public class TranslationHistoryController {
 
     @GetMapping
     @Operation(summary = "번역기록 전체 조회", description = "로그인한 사용자의 전체 번역기록을 조회합니다.")
-    public ResponseEntity<List<TranslationHistoryResponse>> getAllHistories(
-            @Parameter(hidden = true) @AuthenticationPrincipal String email) {
+    public ResponseEntity<List<TranslationHistoryResponse>> getAllHistories(Authentication authentication) {
+        String email = (String) authentication.getPrincipal(); // principal은 String으로 설정되어 있음
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
         List<TranslationHistoryResponse> response = historyService.getAllHistoriesByMember(member);
         return ResponseEntity.ok(response);
     }
+
 }

--- a/src/main/java/com/signwave/signwave/controller/TranslationHistoryController.java
+++ b/src/main/java/com/signwave/signwave/controller/TranslationHistoryController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Parameter;
 
 import java.util.List;
 
@@ -32,7 +33,8 @@ public class TranslationHistoryController {
 
     @GetMapping
     @Operation(summary = "번역기록 전체 조회", description = "로그인한 사용자의 전체 번역기록을 조회합니다.")
-    public ResponseEntity<List<TranslationHistoryResponse>> getAllHistories(@AuthenticationPrincipal String email) {
+    public ResponseEntity<List<TranslationHistoryResponse>> getAllHistories(
+            @Parameter(hidden = true) @AuthenticationPrincipal String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
         List<TranslationHistoryResponse> response = historyService.getAllHistoriesByMember(member);

--- a/src/main/java/com/signwave/signwave/controller/TranslationHistoryController.java
+++ b/src/main/java/com/signwave/signwave/controller/TranslationHistoryController.java
@@ -1,0 +1,25 @@
+// TranslationHistoryController.java
+package com.signwave.signwave.controller;
+
+import com.signwave.signwave.dto.FavoriteRequest;
+import com.signwave.signwave.dto.FavoriteResponse;
+import com.signwave.signwave.service.TranslationHistoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/history")
+@RequiredArgsConstructor
+public class TranslationHistoryController {
+
+    private final TranslationHistoryService historyService;
+
+    @PostMapping("/favorite")
+    @Operation(summary = "즐겨찾기 등록", description = "특정 번역기록을 즐겨찾기로 등록합니다.")
+    public ResponseEntity<FavoriteResponse> addFavorite(@RequestBody FavoriteRequest request) {
+        FavoriteResponse response = historyService.markAsFavorite(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/signwave/signwave/dto/GestureTranslationResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/GestureTranslationResponse.java
@@ -8,4 +8,5 @@ public class GestureTranslationResponse {
 
     @Schema(description = "자연어로 변환된 문장", example = "병원에 가고 싶어요")
     private String sentence;
+
 }

--- a/src/main/java/com/signwave/signwave/dto/TranslationHistoryResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/TranslationHistoryResponse.java
@@ -1,2 +1,22 @@
-package com.signwave.signwave.dto;public class TranslationHistoryResponse {
+package com.signwave.signwave.dto;
+
+import com.signwave.signwave.entity.TranslationHistory;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TranslationHistoryResponse {
+
+    private Long id;
+    private String translatedText;
+    private boolean isFavorite;
+
+    public static TranslationHistoryResponse fromEntity(TranslationHistory history) {
+        return TranslationHistoryResponse.builder()
+                .id(history.getId())
+                .translatedText(history.getSignLanguageTranslation().getTranslatedText())
+                .isFavorite(history.isFavorite())
+                .build();
+    }
 }

--- a/src/main/java/com/signwave/signwave/dto/TranslationHistoryResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/TranslationHistoryResponse.java
@@ -1,0 +1,2 @@
+package com.signwave.signwave.dto;public class TranslationHistoryResponse {
+}

--- a/src/main/java/com/signwave/signwave/dto/TranslationHistoryResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/TranslationHistoryResponse.java
@@ -8,13 +8,13 @@ import lombok.Getter;
 @Builder
 public class TranslationHistoryResponse {
 
-    private Long id;
+    private Long translationHistoryId;
     private String translatedText;
     private boolean isFavorite;
 
     public static TranslationHistoryResponse fromEntity(TranslationHistory history) {
         return TranslationHistoryResponse.builder()
-                .id(history.getId())
+                .translationHistoryId(history.getId())
                 .translatedText(history.getSignLanguageTranslation().getTranslatedText())
                 .isFavorite(history.isFavorite())
                 .build();

--- a/src/main/java/com/signwave/signwave/entity/SignLanguageTranslation.java
+++ b/src/main/java/com/signwave/signwave/entity/SignLanguageTranslation.java
@@ -20,7 +20,7 @@ public class SignLanguageTranslation extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String signLanguageInput;  // 수어 입력 데이터 (예: JSON 등)
 
     private String translatedText;

--- a/src/main/java/com/signwave/signwave/entity/TranslationHistory.java
+++ b/src/main/java/com/signwave/signwave/entity/TranslationHistory.java
@@ -15,7 +15,7 @@ public class TranslationHistory extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "sign_language_translation_id", nullable = false)
     private SignLanguageTranslation signLanguageTranslation;
 

--- a/src/main/java/com/signwave/signwave/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/signwave/signwave/jwt/JwtAuthenticationFilter.java
@@ -18,6 +18,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider tokenProvider;
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        return path.startsWith("/auth/login") ||
+                path.startsWith("/auth/signup");  // ← 이 줄 추가
+    }
+
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain)

--- a/src/main/java/com/signwave/signwave/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/signwave/signwave/jwt/JwtAuthenticationFilter.java
@@ -6,11 +6,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -20,10 +22,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        return path.startsWith("/auth/login") ||
-                path.startsWith("/auth/signup");  // ← 이 줄 추가
+        return path.startsWith("/auth/login") || path.startsWith("/auth/signup");
     }
-
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -36,8 +36,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null && tokenProvider.validateToken(token)) {
             String email = tokenProvider.getEmailFromToken(token);
 
+            // ROLE_USER 권한을 가진 인증 객체 생성
             UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(email, null, null);
+                    new UsernamePasswordAuthenticationToken(
+                            email,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                    );
 
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/signwave/signwave/repository/TranslationHistoryRepository.java
+++ b/src/main/java/com/signwave/signwave/repository/TranslationHistoryRepository.java
@@ -1,9 +1,11 @@
 package com.signwave.signwave.repository;
 
+import com.signwave.signwave.entity.Member;
 import com.signwave.signwave.entity.TranslationHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import java.util.List;
+
 public interface TranslationHistoryRepository extends JpaRepository<TranslationHistory, Long> {
+    List<TranslationHistory> findByMember(Member member);
 }

--- a/src/main/java/com/signwave/signwave/service/GestureTranslationService.java
+++ b/src/main/java/com/signwave/signwave/service/GestureTranslationService.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.List;
 import java.util.Map;
@@ -33,19 +35,15 @@ public class GestureTranslationService {
      * 제스처 시퀀스를 번역하고 DB에 저장하며, 번역 문장을 반환
      */
     public String getTranslatedSentence(List<List<Float>> sequence) {
-        // 1. 더미 사용자 이메일 기준으로 찾거나
-        Member member = memberRepository.findByEmail("test@dummy.com")
-                .orElseGet(() -> {
-                    // 2. 없으면 생성 후 저장
-                    Member dummy = Member.builder()
-                            .email("test@dummy.com")
-                            .password("dummy")      // 보안 상 사용하지 않는 값
-                            .nickname("dummy")
-                            .build();
-                    return memberRepository.save(dummy);
-                });
+        // 🔐 JWT로부터 이메일 꺼내기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
 
-        // 3. 번역 및 저장
+        // 🔍 해당 이메일로 회원 정보 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 회원을 찾을 수 없습니다."));
+
+        // 🚀 번역 및 저장
         return translateAndSave(sequence, member);
     }
 

--- a/src/main/java/com/signwave/signwave/service/TranslationHistoryService.java
+++ b/src/main/java/com/signwave/signwave/service/TranslationHistoryService.java
@@ -2,10 +2,14 @@ package com.signwave.signwave.service;
 
 import com.signwave.signwave.dto.FavoriteRequest;
 import com.signwave.signwave.dto.FavoriteResponse;
+import com.signwave.signwave.dto.TranslationHistoryResponse;
+import com.signwave.signwave.entity.Member;
 import com.signwave.signwave.entity.TranslationHistory;
 import com.signwave.signwave.repository.TranslationHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,5 +25,17 @@ public class TranslationHistoryService {
         TranslationHistory updated = historyRepository.save(history);
 
         return new FavoriteResponse(updated.getMember().getId());
+    }
+
+    /**
+     * 특정 회원의 번역기록 전체를 조회하여 응답 DTO 리스트로 반환
+     *
+     * @param member 현재 로그인된 사용자
+     * @return 해당 사용자의 번역기록 리스트 (TranslationHistoryResponse)
+     */
+    public List<TranslationHistoryResponse> getAllHistoriesByMember(Member member) {
+        return historyRepository.findByMember(member).stream()
+                .map(TranslationHistoryResponse::fromEntity)
+                .toList();
     }
 }

--- a/src/main/java/com/signwave/signwave/service/TranslationHistoryService.java
+++ b/src/main/java/com/signwave/signwave/service/TranslationHistoryService.java
@@ -8,6 +8,7 @@ import com.signwave.signwave.entity.TranslationHistory;
 import com.signwave.signwave.repository.TranslationHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -33,6 +34,7 @@ public class TranslationHistoryService {
      * @param member 현재 로그인된 사용자
      * @return 해당 사용자의 번역기록 리스트 (TranslationHistoryResponse)
      */
+    @Transactional(readOnly = true)
     public List<TranslationHistoryResponse> getAllHistoriesByMember(Member member) {
         return historyRepository.findByMember(member).stream()
                 .map(TranslationHistoryResponse::fromEntity)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://db:5432/sign_db
+    url: jdbc:postgresql://db:5432/sign_db?autoCommit=false
     username: sign_user
     password: sign_pass
   config:
@@ -8,11 +8,14 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create  # ★ 여기를 update → create 로 변경
     show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        jdbc:
+          lob:
+            non_contextual_creation: true  # ★ LOB 스트리밍 방지 옵션 추가
 
 server:
   port: 8080


### PR DESCRIPTION
### 연관된 이슈
- #10 

### 작업 내용
- 로그인한 사용자의 번역 기록 전체를 조회하는 API 구현 (GET /history)
- JWT 인증 기반으로 사용자의 이메일을 추출하여 해당 회원의 번역기록을 조회
TranslationHistoryService에서 getAllHistoriesByMember(Member) 메서드 구현
- 엔티티 TranslationHistory와 연관된 SignLanguageTranslation의 translatedText를 함께 응답
- 응답 DTO TranslationHistoryResponse에 translationHistoryId, translatedText, isFavorite 포함
- Swagger에서 로그인 후 Authorize 버튼을 통해 API 테스트 가능하도록 설정

