### PR TITLE
Feat/add hospitalreservation#6

### DIFF
--- a/src/main/java/com/signwave/signwave/controller/HospitalReservationController.java
+++ b/src/main/java/com/signwave/signwave/controller/HospitalReservationController.java
@@ -1,0 +1,35 @@
+package com.signwave.signwave.controller;
+
+import com.signwave.signwave.dto.HospitalReservationRequest;
+import com.signwave.signwave.dto.HospitalReservationResponse;
+import com.signwave.signwave.entity.Member;
+import com.signwave.signwave.repository.MemberRepository;
+import com.signwave.signwave.service.HospitalReservationService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/reservations")
+@RequiredArgsConstructor
+public class HospitalReservationController {
+
+    private final HospitalReservationService reservationService;
+    private final MemberRepository memberRepository;
+
+    @PostMapping
+    @Operation(summary = "병원 예약 생성", description = "로그인한 사용자가 병원 예약을 생성합니다.")
+    public ResponseEntity<HospitalReservationResponse> createReservation(
+            @RequestBody HospitalReservationRequest request,
+            Authentication authentication) {
+
+        String email = (String) authentication.getPrincipal();
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 사용자를 찾을 수 없습니다."));
+
+        HospitalReservationResponse response = reservationService.createReservation(request, member);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/signwave/signwave/dto/HospitalReservationRequest.java
+++ b/src/main/java/com/signwave/signwave/dto/HospitalReservationRequest.java
@@ -1,2 +1,10 @@
-package com.signwave.signwave.dto;public class HospitalReservationRequest {
+package com.signwave.signwave.dto;
+
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class HospitalReservationRequest {
+    private String hospitalName;
+    private LocalDateTime reservationTime;
 }

--- a/src/main/java/com/signwave/signwave/dto/HospitalReservationRequest.java
+++ b/src/main/java/com/signwave/signwave/dto/HospitalReservationRequest.java
@@ -1,10 +1,13 @@
 package com.signwave.signwave.dto;
 
 import lombok.Getter;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
 public class HospitalReservationRequest {
     private String hospitalName;
+    private LocalDate reservationDate;
     private LocalDateTime reservationTime;
 }

--- a/src/main/java/com/signwave/signwave/dto/HospitalReservationRequest.java
+++ b/src/main/java/com/signwave/signwave/dto/HospitalReservationRequest.java
@@ -1,0 +1,2 @@
+package com.signwave.signwave.dto;public class HospitalReservationRequest {
+}

--- a/src/main/java/com/signwave/signwave/dto/HospitalReservationResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/HospitalReservationResponse.java
@@ -4,11 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 @Builder
 @AllArgsConstructor
 public class HospitalReservationResponse {
     private Long reservationId;
     private String hospitalName;
+    private LocalDate reservationDate;
     private String reservationTime;
 }

--- a/src/main/java/com/signwave/signwave/dto/HospitalReservationResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/HospitalReservationResponse.java
@@ -1,2 +1,12 @@
-package com.signwave.signwave.dto;public class HospitalReservationResponse {
+package com.signwave.signwave.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HospitalReservationResponse {
+    private Long reservationId;
+    private String hospitalName;
+    private String reservationTime;
 }

--- a/src/main/java/com/signwave/signwave/dto/HospitalReservationResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/HospitalReservationResponse.java
@@ -12,6 +12,6 @@ import java.time.LocalDate;
 public class HospitalReservationResponse {
     private Long reservationId;
     private String hospitalName;
-    private LocalDate reservationDate;
-    private String reservationTime;
+    private String reservationDate; // "2025-05-09"
+    private String reservationTime;    // "15:30"
 }

--- a/src/main/java/com/signwave/signwave/dto/HospitalReservationResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/HospitalReservationResponse.java
@@ -1,9 +1,11 @@
 package com.signwave.signwave.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class HospitalReservationResponse {
     private Long reservationId;

--- a/src/main/java/com/signwave/signwave/dto/HospitalReservationResponse.java
+++ b/src/main/java/com/signwave/signwave/dto/HospitalReservationResponse.java
@@ -1,0 +1,2 @@
+package com.signwave.signwave.dto;public class HospitalReservationResponse {
+}

--- a/src/main/java/com/signwave/signwave/entity/HospitalReservation.java
+++ b/src/main/java/com/signwave/signwave/entity/HospitalReservation.java
@@ -27,6 +27,10 @@ public class HospitalReservation {
     @Column(nullable = false)
     private LocalDateTime reservationTime;
 
+    @Column(nullable = false)
+    private LocalDate reservationDate;
+
+
     public void update(String hospitalName, LocalDateTime reservationTime) {
         this.hospitalName = hospitalName;
         this.reservationTime = reservationTime;

--- a/src/main/java/com/signwave/signwave/repository/HospitalReservationRepository.java
+++ b/src/main/java/com/signwave/signwave/repository/HospitalReservationRepository.java
@@ -1,9 +1,13 @@
 package com.signwave.signwave.repository;
 
 import com.signwave.signwave.entity.HospitalReservation;
+import com.signwave.signwave.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface HospitalReservationRepository extends JpaRepository<HospitalReservation, Long> {
+    List<HospitalReservation> findByMember(Member member);
 }

--- a/src/main/java/com/signwave/signwave/service/HospitalReservationService.java
+++ b/src/main/java/com/signwave/signwave/service/HospitalReservationService.java
@@ -1,0 +1,39 @@
+package com.signwave.signwave.service;
+
+import com.signwave.signwave.dto.HospitalReservationRequest;
+import com.signwave.signwave.dto.HospitalReservationResponse;
+import com.signwave.signwave.entity.HospitalReservation;
+import com.signwave.signwave.entity.Member;
+import com.signwave.signwave.repository.HospitalReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HospitalReservationService {
+
+    private final HospitalReservationRepository reservationRepository;
+
+    @Transactional
+    public HospitalReservationResponse reserve(Member member, HospitalReservationRequest request) {
+        HospitalReservation reservation = HospitalReservation.builder()
+                .member(member)
+                .hospitalName(request.getHospitalName())
+                .reservationTime(request.getReservationTime())
+                .build();
+
+        HospitalReservation saved = reservationRepository.save(reservation);
+        return new HospitalReservationResponse(saved.getId(), saved.getHospitalName(), saved.getReservationTime().toString());
+    }
+
+    @Transactional(readOnly = true)
+    public List<HospitalReservationResponse> getReservations(Member member) {
+        return reservationRepository.findByMember(member).stream()
+                .map(r -> new HospitalReservationResponse(r.getId(), r.getHospitalName(), r.getReservationTime().toString()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/signwave/signwave/service/HospitalReservationService.java
+++ b/src/main/java/com/signwave/signwave/service/HospitalReservationService.java
@@ -7,10 +7,8 @@ import com.signwave.signwave.entity.Member;
 import com.signwave.signwave.repository.HospitalReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
@@ -18,22 +16,30 @@ public class HospitalReservationService {
 
     private final HospitalReservationRepository reservationRepository;
 
-    @Transactional
-    public HospitalReservationResponse reserve(Member member, HospitalReservationRequest request) {
+    public HospitalReservationResponse createReservation(HospitalReservationRequest request, Member member) {
         HospitalReservation reservation = HospitalReservation.builder()
-                .member(member)
                 .hospitalName(request.getHospitalName())
+                .reservationDate(request.getReservationDate())
                 .reservationTime(request.getReservationTime())
+                .member(member)
                 .build();
 
         HospitalReservation saved = reservationRepository.save(reservation);
-        return new HospitalReservationResponse(saved.getId(), saved.getHospitalName(), saved.getReservationTime().toString());
-    }
 
-    @Transactional(readOnly = true)
-    public List<HospitalReservationResponse> getReservations(Member member) {
-        return reservationRepository.findByMember(member).stream()
-                .map(r -> new HospitalReservationResponse(r.getId(), r.getHospitalName(), r.getReservationTime().toString()))
-                .collect(Collectors.toList());
+        String formattedDate = saved.getReservationDate()
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        // HH:mm 형식으로 포맷 (예: 15:30)
+        String formattedTime = saved.getReservationTime()
+                .toLocalTime()
+                .format(DateTimeFormatter.ofPattern("HH:mm"));
+
+        return HospitalReservationResponse.builder()
+                .reservationId(saved.getId())
+                .hospitalName(saved.getHospitalName())
+                .reservationDate(formattedDate)
+                .reservationTime(formattedTime)
+                .build();
+
     }
 }


### PR DESCRIPTION
### 연관된 이슈
- #6 

### 작업 내용
- HospitalReservation 엔티티에 reservationDate(LocalDate) 필드 추가
- 병원 이름, 예약 날짜(yyyy-MM-dd), 예약 시간(HH:mm)을 입력받는 HospitalReservationRequest DTO 작성
- 예약 정보를 클라이언트에 반환하는 HospitalReservationResponse DTO 작성
- 날짜 및 시간 포맷을 지정해 응답 (String 타입으로 변환)
- 로그인된 사용자 기반 예약 저장 로직 구현 (HospitalReservationService)
- /reservations POST 요청 처리하는 컨트롤러 메서드 추가
-  Swagger 문서화 어노테이션 추가
-  기능 테스트 및 응답 형식 확인