### PR TITLE
Feat/hospitalreservation delete#14

### DIFF
--- a/src/main/java/com/signwave/signwave/controller/HospitalReservationController.java
+++ b/src/main/java/com/signwave/signwave/controller/HospitalReservationController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/reservations")
 @RequiredArgsConstructor
@@ -35,7 +37,7 @@ public class HospitalReservationController {
 
     @DeleteMapping("/{reservationId}")
     @Operation(summary = "병원 예약 삭제", description = "로그인한 사용자가 병원 예약을 삭제합니다.")
-    public ResponseEntity<Void> deleteReservation(
+    public ResponseEntity<Map<String, String>> deleteReservation(
             @PathVariable Long reservationId,
             Authentication authentication) {
 
@@ -44,7 +46,10 @@ public class HospitalReservationController {
                 .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 사용자를 찾을 수 없습니다."));
 
         reservationService.deleteReservation(reservationId, member);
-        return ResponseEntity.noContent().build();
+
+        Map<String, String> response = Map.of("message", "병원 예약이 성공적으로 삭제되었습니다.");
+        return ResponseEntity.ok(response);
     }
+
 
 }

--- a/src/main/java/com/signwave/signwave/controller/HospitalReservationController.java
+++ b/src/main/java/com/signwave/signwave/controller/HospitalReservationController.java
@@ -32,4 +32,19 @@ public class HospitalReservationController {
         HospitalReservationResponse response = reservationService.createReservation(request, member);
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{reservationId}")
+    @Operation(summary = "병원 예약 삭제", description = "로그인한 사용자가 병원 예약을 삭제합니다.")
+    public ResponseEntity<Void> deleteReservation(
+            @PathVariable Long reservationId,
+            Authentication authentication) {
+
+        String email = (String) authentication.getPrincipal();
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 사용자를 찾을 수 없습니다."));
+
+        reservationService.deleteReservation(reservationId, member);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/signwave/signwave/service/HospitalReservationService.java
+++ b/src/main/java/com/signwave/signwave/service/HospitalReservationService.java
@@ -7,6 +7,7 @@ import com.signwave.signwave.entity.Member;
 import com.signwave.signwave.repository.HospitalReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.format.DateTimeFormatter;
 
@@ -42,4 +43,17 @@ public class HospitalReservationService {
                 .build();
 
     }
+
+    @Transactional
+    public void deleteReservation(Long reservationId, Member member) {
+        HospitalReservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 예약이 존재하지 않습니다."));
+
+        if (!reservation.getMember().getId().equals(member.getId())) {
+            throw new IllegalArgumentException("해당 예약을 삭제할 권한이 없습니다.");
+        }
+
+        reservationRepository.delete(reservation);
+    }
+
 }

--- a/src/main/java/com/signwave/signwave/service/HospitalReservationService.java
+++ b/src/main/java/com/signwave/signwave/service/HospitalReservationService.java
@@ -47,7 +47,7 @@ public class HospitalReservationService {
     @Transactional
     public void deleteReservation(Long reservationId, Member member) {
         HospitalReservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 예약이 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 예약이 존재하지 않습니다"));
 
         if (!reservation.getMember().getId().equals(member.getId())) {
             throw new IllegalArgumentException("해당 예약을 삭제할 권한이 없습니다.");


### PR DESCRIPTION
### 연관된 이슈
- #14 

### 작업 내용
- DELETE 엔드포인트 추가
@DeleteMapping("/reservations/{reservationId}")로 삭제 API 정의
Swagger 문서화: @Operation(summary = "병원 예약 삭제", description = "로그인한 사용자가 병원 예약을 삭제합니다.")
- 인증된 사용자 식별
Authentication 객체에서 이메일 추출 후 Member 조회
존재하지 않으면 예외 처리
- 권한 검증 및 삭제 처리
요청된 예약 ID를 DB에서 조회
해당 예약의 소유자가 현재 로그인한 사용자와 다르면 삭제 불가
삭제 가능 시 reservationRepository.delete()로 삭제 수행